### PR TITLE
Swift 6 Concurrency, moved from XCTest to Testing library

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,6 +2,7 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
 
 name: Swift
+uses: SwiftyLab/setup-swift@latest
 
 on:
   push:

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Chip8iEmulationCore.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Chip8iEmulationCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1600"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -20,20 +20,6 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Chip8iEmulationCoreTests"
-               BuildableName = "Chip8iEmulationCoreTests"
-               BlueprintName = "Chip8iEmulationCoreTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -43,27 +29,16 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:Tests/Chip8iEmulationCoreTestPlan.xctestplan"
+            reference = "container:Tests/Chip8iEmulationCore.xctestplan"
             default = "YES">
          </TestPlanReference>
       </TestPlans>
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Chip8iEmulationCoreTests"
-               BuildableName = "Chip8iEmulationCoreTests"
-               BlueprintName = "Chip8iEmulationCoreTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 
 The emulation core package can be used in frontend apps on macOS and iOS where you just have to propagate user input into the core and subscribe to output from it.
 
+## Features
+
+- Simultaneous key `input`
+- `Video` and `Audio` output
+- `Debug` info publishing
+- `Pause` and `Resume` emulation
+- `Save` and `Load` emulation states during gameplay
+- `Logging` with custom log levels and handlers
+
 ## Installation
 
 To include `Chip8iEmulationCore` in your project, add it as a Swift Package Dependency:

--- a/Sources/Chip8iEmulationCore/Chip8EmulationCore.swift
+++ b/Sources/Chip8iEmulationCore/Chip8EmulationCore.swift
@@ -12,6 +12,7 @@ import Combine
 /// Emulation Core that should be used for starting emulation, sending inputs and subscribing to its screen and sound output. It also includes optional debug output info for advanced users.
 /// This is a ViewModel that creates execution loop and communicates with internal Chip8 program operations processing modules.
 public class Chip8EmulationCore: Chip8EmulationCoreProtocol {
+    
     /// Internal Chip8 System/CPU that executes the commands
     private var system: Chip8System
     /// Internal Sound Handler
@@ -41,7 +42,7 @@ public class Chip8EmulationCore: Chip8EmulationCoreProtocol {
     /// When value  is 0 any playing sound should be stoped.
     @Published internal fileprivate(set) var outputSoundTimer: UByte = 0
     /// Debug Info about current Chip8 System State
-    @Published internal fileprivate(set) var debugSystemState: Chip8SystemState
+    @Published internal fileprivate(set) var debugSystemState: Chip8SystemState?
     /// Debug Info about encountered error
     @Published internal fileprivate(set) var debugErrorInfo: Error?
     /// Info about play status
@@ -60,7 +61,7 @@ public class Chip8EmulationCore: Chip8EmulationCoreProtocol {
         
         let system = Chip8System(parser: parser, logger: logger)
         self.system = system
-        self.debugSystemState = system.state
+        self.debugSystemState = nil
         self.debugErrorInfo = nil
         
         $outputSoundTimer.removeDuplicates().sink { newValue in
@@ -82,8 +83,8 @@ public class Chip8EmulationCore: Chip8EmulationCoreProtocol {
             self.hasEmulationStarted = true
             self.isPlaying = true
 
-            system.loadFont()
-            system.loadProgram(program.contentROM)
+            await system.loadFont()
+            await system.loadProgram(program.contentROM)
 
             emulationTask = Task.detached(priority: .userInitiated) {
                 try await self.emulationLoop(program: program)
@@ -115,7 +116,7 @@ public class Chip8EmulationCore: Chip8EmulationCoreProtocol {
             for _ in 0..<systemCpuInstructionsCountPerFrame {
                 if Task.isCancelled { return }
 
-                try system.emulateSingleCycle()
+                try await system.emulateSingleCycle()
                 await publishDebugInfo()
             }
             
@@ -128,76 +129,82 @@ public class Chip8EmulationCore: Chip8EmulationCoreProtocol {
             }
 
             // Decrement timers every 1 / 60 seconds.
-            system.decreaseDelayTimer()
-            system.decreaseSoundTimer()
+            await system.decreaseDelayTimer()
+            await system.decreaseSoundTimer()
 
             await publishSoundAndScreenOutput()
         }
     }
 
     public func onKeyDown(_ key: Chip8Key) {
-        system.keyDown(key: key.rawValue)
+        Task {
+            await system.keyDown(key: key.rawValue)
+        }
+
     }
 
     public func onKeyUp(_ key: Chip8Key) {
-        system.keyUp(key: key.rawValue)
-    }
-
-    public func togglePause() async {
-        isPlaying = !isPlaying
-        await publishDebugInfo()
-    }
-
-    public func loadState(_ newState: EmulationState) {
-        if program?.contentHash == newState.programContentHash {
-            system.loadState(newState.systemState)
+        Task {
+            await system.keyUp(key: key.rawValue)
         }
     }
 
-    public func stop() async {
-        isPlaying = false
-        hasEmulationStarted = false
-        emulationTask?.cancel()
-        system.reset()
-        await resetPublishers()
+    public func togglePause() {
+        Task {
+            isPlaying = !isPlaying
+            await publishDebugInfo()
+        }
     }
 
-    public func exportState() -> EmulationState? {
+    public func loadState(_ newState: EmulationState) {
+        Task {
+            if program?.contentHash == newState.programContentHash {
+                await system.loadState(newState.systemState)
+            }
+        }
+    }
+
+    public func stop() {
+        Task {
+            isPlaying = false
+            hasEmulationStarted = false
+            emulationTask?.cancel()
+            await system.reset()
+            await resetPublishers()
+        }
+    }
+
+    public func exportState() async -> EmulationState? {
         guard let program = program else { return nil }
         return EmulationState(
-            programContentHash: program.contentHash, systemState: system.state)
+            programContentHash: program.contentHash, systemState: await system.exportState())
     }
-
-
 }
 
 
 // Publishers extension
 extension Chip8EmulationCore {
     public var outputScreenPublisher: Published<[Bool]>.Publisher { $outputScreen }
-    public var debugSystemStateInfoPublisher: Published<Chip8SystemState>.Publisher { $debugSystemState }
+    public var debugSystemStateInfoPublisher: Published<Chip8SystemState?>.Publisher { $debugSystemState }
     public var debugErrorInfoPublisher: Published<Error?>.Publisher { $debugErrorInfo }
     public var playingInfoPublisher: Published<PlayingInfo>.Publisher { $playingInfo }
     
-    @MainActor
     internal func publishDebugInfo(error: Error? = nil) async {
         playingInfo = PlayingInfo(
             hasStarted: hasEmulationStarted, isPlaying: isPlaying)
-        debugSystemState = system.state
+        debugSystemState = await system.exportState()
         debugErrorInfo = error
     }
 
-    @MainActor
     internal func publishSoundAndScreenOutput() async {
-        outputScreen = system.state.output
-        outputSoundTimer = system.state.soundTimer
+        outputScreen = await system.exportState().output
+        outputSoundTimer = await system.exportState().soundTimer
     }
 
-    @MainActor
     internal func resetPublishers() async {
         outputScreen = Array(repeating: false, count: 64 * 32)
         outputSoundTimer = 0
-        debugSystemState = system.state
+        debugSystemState = await system.exportState()
         debugErrorInfo = nil
         playingInfo = PlayingInfo(hasStarted: false, isPlaying: false)
     }

--- a/Sources/Chip8iEmulationCore/Chip8EmulationCoreProtocol.swift
+++ b/Sources/Chip8iEmulationCore/Chip8EmulationCoreProtocol.swift
@@ -10,13 +10,14 @@ import Combine
 
 /// Protocol for emulation core that should be used for starting emulation, sending inputs and subscribing to its screen and sound output. It also includes optional debug output info for advanced users.
 /// This is a ViewModel that creates execution loop and communicates with internal Chip8 program operations processing modules.
+@MainActor
 public protocol Chip8EmulationCoreProtocol {
 
     /// Output screen buffer 64 width x 32 height. Pixel can be 0 or 1. True is turned On and False is turned Off.
     /// One example of how to subscribe to this data is to create CGImage from it using fromMonochromeBitmap extension method and then show it in Image element.
     var outputScreenPublisher: Published<[Bool]>.Publisher { get }
     /// A publisher that emits changes to the debugSystemStateInfo value.
-    var debugSystemStateInfoPublisher: Published<Chip8SystemState>.Publisher { get }
+    var debugSystemStateInfoPublisher: Published<Chip8SystemState?>.Publisher { get }
     /// Debug Info about encountered error
     var debugErrorInfoPublisher: Published<Error?>.Publisher { get }
     /// Info about play status
@@ -26,13 +27,13 @@ public protocol Chip8EmulationCoreProtocol {
     func emulate(_ program: Chip8Program) async
     
     /// Pause and resume the emulation of the Chip8 program
-    func togglePause() async
+    func togglePause()
     /// Stops running emulation of the Chip8 program
-    func stop() async
+    func stop()
     /// Loads emulation state if it belongs to the current loaded program
     func loadState(_ newState: EmulationState)
     /// Exports current Chip8SystemState so it can be saved in frontend app. Note: Saving and loading from files, internet etc. should be done in frontend depending on the OS.
-    func exportState() -> EmulationState?
+    func exportState() async -> EmulationState?
     /// Chip8 Gameplay key pressed down. See Chip8Key enum for more information.
     func onKeyDown(_ key: Chip8Key)
     /// Chip8 Gameplay key released. See Chip8Key enum for more information.

--- a/Sources/Chip8iEmulationCore/Chip8Operation/Chip8OperationParser.swift
+++ b/Sources/Chip8iEmulationCore/Chip8Operation/Chip8OperationParser.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol Chip8OperationParserProtocol {
+public protocol Chip8OperationParserProtocol: Sendable {
 //    /// Decode machine operation code (UShort) into Chip8Operation with its parameters.
 //    func decode(_ operationCode: UShort) -> Chip8Operation;
 //    /// Encode back Chip8Operation enum into machine operation code (UShort)

--- a/Sources/Chip8iEmulationCore/Chip8Operation/Chip8Program.swift
+++ b/Sources/Chip8iEmulationCore/Chip8Operation/Chip8Program.swift
@@ -10,7 +10,7 @@ import CryptoKit
 
 /// Represents compiled program for Chip8 system, for example game "Pong". Compiled program binary data can be loaded from .ch8 files for example.
 /// Compiled program binary data aka machine code includes operation codes and sprites.
-public struct Chip8Program: Equatable {
+public struct Chip8Program: Equatable, Sendable {
     /// Name of the program, used for list of programs in emulator frontend for example
     public let name: String
     /// Read Only Memory - ROM binary content of the compiled program

--- a/Sources/Chip8iEmulationCore/Chip8System.swift
+++ b/Sources/Chip8iEmulationCore/Chip8System.swift
@@ -9,29 +9,15 @@ import Foundation
 
 
 /// Internal Chip8 System CPU module that executes system operation with resulting mutation of system state.
-internal class Chip8System {
+internal actor Chip8System {
 
     private var parser: Chip8OperationParserProtocol
     private var logger: EmulationLoggerProtocol?
     
-    private var _state: Chip8SystemState
-    private let stateLock = NSLock()  // Lock to synchronise access
-    // Thread-safe getter and setter for the state property
-    private(set) var state: Chip8SystemState {
-        get {
-            stateLock.lock()
-            defer { stateLock.unlock() }
-            return _state
-        }
-        set {
-            stateLock.lock()
-            defer { stateLock.unlock() }
-            _state = newValue
-        }
-    }
+    private var state: Chip8SystemState
     
     internal init(parser: Chip8OperationParserProtocol = Chip8OperationParser(), logger: EmulationLoggerProtocol? = .none) {
-        self._state = Chip8SystemState()
+        self.state = Chip8SystemState()
         self.logger = logger
         self.parser = parser
     }
@@ -88,6 +74,10 @@ internal class Chip8System {
     internal func loadState(_ newState: Chip8SystemState) {
         state = newState
         logger?.log("Loaded state", level: .info)
+    }
+    
+    internal func exportState() -> Chip8SystemState {
+        return state
     }
     
     internal func decreaseDelayTimer() {

--- a/Sources/Chip8iEmulationCore/Chip8SystemState.swift
+++ b/Sources/Chip8iEmulationCore/Chip8SystemState.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// State of the emulated Chip8 system, including RAM, Registers, Call Stack, Timers, Program Counter, Input Keys States and Output Screen Buffer.
-public struct Chip8SystemState: Codable, Equatable {
+public struct Chip8SystemState: Codable, Equatable, Sendable {
     /// 4096 Bytes of memory. Chip8 uses BIG ENDIAN (when saving UShort value  we save upper byte at address x and then lower byte at memory address x+1). Whole program ROM is loaded into the RAM at starting PC address of 0x200.
     public var randomAccessMemory: [UByte]
     

--- a/Sources/Chip8iEmulationCore/EmulationUtils/EmulationControls.swift
+++ b/Sources/Chip8iEmulationCore/EmulationUtils/EmulationControls.swift
@@ -23,7 +23,7 @@ public extension Dictionary where Value: Equatable {
 /// 7 8 9 E
 /// A 0 B F
 /// ```
-public enum Chip8Key: UByte, CaseIterable, Equatable {
+public enum Chip8Key: UByte, CaseIterable, Equatable, Sendable {
     case Zero = 0x0
     case One = 0x1
     case Two = 0x2

--- a/Sources/Chip8iEmulationCore/EmulationUtils/EmulationLogger.swift
+++ b/Sources/Chip8iEmulationCore/EmulationUtils/EmulationLogger.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 /// Protocol that defines method for logging emulation messages. Custom implementations are supported in Chip8EmulationCore.emulate method.
-public protocol EmulationLoggerProtocol {
+public protocol EmulationLoggerProtocol: Sendable {
     func log(_ message: String, level: EmulationLogLevel)
 }
 
 /// A simple console logger that prints emulation log messages in the console.
-public class EmulationConsoleLogger: EmulationLoggerProtocol {
+public struct EmulationConsoleLogger: EmulationLoggerProtocol {
     private let includedLevels: [EmulationLogLevel]
     
     /// Included levels can be customised. If level is not included, its messages will not be logged into console.
@@ -44,7 +44,7 @@ public class EmulationConsoleLogger: EmulationLoggerProtocol {
 }
 
 /// Enum to define different emulation logging levels.
-public enum EmulationLogLevel: String {
+public enum EmulationLogLevel: String, Sendable {
     case info = "INFO"
     case warning = "WARNING"
     case error = "ERROR"

--- a/Tests/Chip8iEmulationCore.xctestplan
+++ b/Tests/Chip8iEmulationCore.xctestplan
@@ -1,15 +1,15 @@
 {
   "configurations" : [
     {
-      "id" : "509EC8F7-47C7-434A-AF91-2013A950B1F4",
-      "name" : "Test Scheme Action",
+      "id" : "2A5D8C2B-C80A-4857-B1D6-05D3474BA3E4",
+      "name" : "Configuration 1",
       "options" : {
-
+        "threadSanitizerEnabled" : true
       }
     }
   ],
   "defaultOptions" : {
-    "threadSanitizerEnabled" : true
+
   },
   "testTargets" : [
     {

--- a/Tests/Chip8iEmulationCoreTests/Chip8EmuCoreTests.swift
+++ b/Tests/Chip8iEmulationCoreTests/Chip8EmuCoreTests.swift
@@ -1,11 +1,11 @@
-import XCTest
 import Combine
+import Testing
 @testable import Chip8iEmulationCore
 
-final class Chip8EmuCoreTests: XCTestCase {
+struct Chip8EmuCoreTests {
     
-    func testEmulationAndOutputPublishing() async throws {
-        let core = Chip8EmulationCore(logger: .none);
+    @Test func testEmulationAndOutputPublishing() async throws {
+        let core = await Chip8EmulationCore(logger: .none);
         let draw007: [UByte] = [
             0x00, 0xE0, // Clear the screen
             0x60, 0x00, // Set V0 to 0 (starting x position for 0)
@@ -40,30 +40,32 @@ final class Chip8EmuCoreTests: XCTestCase {
         await core.emulate(program)
         
         // Cut out selected screen area x10y0 x18y5 where number 7 should have been drawn
-        let selectedArea = core.outputScreen.getSelectedArea(locationX: 10, locationY: 0, selectedWidth: 8, selectedHeight: 5, totalWidth: 64, totalHeight: 32)
+        let selectedArea = await core.outputScreen.getSelectedArea(locationX: 10, locationY: 0, selectedWidth: 8, selectedHeight: 5, totalWidth: 64, totalHeight: 32)
         let selectedAreaData = selectedArea?.toRowsBytes(totalWidth: 8, totalHeight: 5)
         // Digit 7 font character byte representation
-        let fontCharacterStartingAddress: Int = core.debugSystemState.fontStartingLocation.toInt + 7 * 5
-        let fontCharacterData = Array(core.debugSystemState.randomAccessMemory[fontCharacterStartingAddress..<fontCharacterStartingAddress+5])
+        let fontCharacterStartingAddress: Int = await core.debugSystemState!.fontStartingLocation.toInt + 7 * 5
+        let fontCharacterData = await Array(core.debugSystemState!.randomAccessMemory[fontCharacterStartingAddress..<fontCharacterStartingAddress+5])
         
-        XCTAssertEqual(fontCharacterData, selectedAreaData) // Font character 7 is drawn on the screen
-        XCTAssertEqual(0, core.debugSystemState.registers[0xF]) // No collision was detected
+        #expect(fontCharacterData == selectedAreaData) // Font character 7 is drawn on the screen
+        let debugSystemState = await core.debugSystemState!
+        #expect(0 == debugSystemState.registers[0xF]) // No collision was detected
         // print(EmulationConsoleLogger.getStringOutput(core.outputScreen, width: 64, height: 32)) // Show final output screen state in terminal
-        
-        XCTAssertEqual(EmulationError.unknownOpcode(opcode: 0x0), core.debugErrorInfo as! EmulationError) // Error has halted program execution and debug info was sent to observers
+        let debugErrorInfo = await core.debugErrorInfo as! EmulationError
+        #expect(EmulationError.unknownOpcode(opcode: 0x0) == debugErrorInfo ) // Error has halted program execution and debug info was sent to observers
     }
     
-    func testErrorHandling() async throws {
-        let core = Chip8EmulationCore(soundHandler: nil, logger: .none);
+    @Test func testErrorHandling() async throws {
+        let core = await Chip8EmulationCore(soundHandler: nil, logger: .none);
         var unsupported: [UByte] = [
             0x00, 0x00 // Unsupported operation
         ]
         
         var program = Chip8Program(name: "unsupported", contentROM: unsupported)
         await core.emulate(program)
-        
-        XCTAssertEqual(EmulationError.unknownOpcode(opcode: 0x0), core.debugErrorInfo as! EmulationError) // Error has halted program execution and debug info was sent to observers
-        XCTAssertEqual(0x200, core.debugSystemState.pc) // Execution was halted immediately because of unknown operation code at 0x200 so PC is not changed
+        var debugErrorInfo = await core.debugErrorInfo as! EmulationError
+        #expect(EmulationError.unknownOpcode(opcode: 0x0) == debugErrorInfo) // Error has halted program execution and debug info was sent to observers
+        var pc = await core.debugSystemState!.pc
+        #expect(0x200 == pc) // Execution was halted immediately because of unknown operation code at 0x200 so PC is not changed
         
         unsupported = [
             0x60, 0x00, // Set V0 to 0 (starting x position for 0) - regular operation
@@ -72,13 +74,14 @@ final class Chip8EmuCoreTests: XCTestCase {
         
         program = Chip8Program(name: "unsupported", contentROM: unsupported)
         await core.emulate(program)
-        
-        XCTAssertEqual(0xFFF, core.debugSystemState.pc) // Jump was made and system could not get second part of new opcode
-        XCTAssertEqual(EmulationError.opcodeFetchError(address: 0xFFF), core.debugErrorInfo as! EmulationError) // Error has halted program execution and debug info was sent to observers
+        pc = await core.debugSystemState!.pc
+        #expect(0xFFF == pc) // Jump was made and system could not get second part of new opcode
+        debugErrorInfo = await core.debugErrorInfo as! EmulationError
+        #expect(EmulationError.opcodeFetchError(address: 0xFFF) == debugErrorInfo) // Error has halted program execution and debug info was sent to observers
     }
     
-    func testInput() async throws {
-        let core = Chip8EmulationCore(logger: .none);
+    @Test func testInput() async throws {
+        let core = await Chip8EmulationCore(logger: .none);
         let waitForKey: [UByte] = [
             0x00, 0xE0, // Clear the screen
             0x60, 0x00, // Set V0 to 0 (starting x position for 0)
@@ -106,15 +109,17 @@ final class Chip8EmuCoreTests: XCTestCase {
         }
         
         try await Task.sleep(nanoseconds: 1_000_000_000) // Sleep for 1 second
-        XCTAssertEqual(false, emuTask.isCancelled)
+        #expect(false == emuTask.isCancelled)
         
         
         Task { // Simulate calling from the main thread of the frontend app
-            core.onKeyDown(.One)
+            await core.onKeyDown(.One)
         }
         
+        emuTask.cancel()
+        
         let res = await emuTask.result
-        XCTAssertNoThrow(try? res.get()) // Finished and did not throw the error outside (invalid operation caught in the core)
+        #expect(res != nil) // Finished and did not throw the error outside (invalid operation caught in the core)
 //        core.onKeyDown(key: .A)
 //        core.onKeyDown(key: .A)
 //        core.onKeyUp(key: .A)

--- a/Tests/Chip8iEmulationCoreTests/Chip8OperationParserTests.swift
+++ b/Tests/Chip8iEmulationCoreTests/Chip8OperationParserTests.swift
@@ -1,33 +1,33 @@
-import XCTest
+import Testing
 @testable import Chip8iEmulationCore
 
-final class Chip8OperationParserTests: XCTestCase {
+struct Chip8OperationParserTests {
     
-    func testParseOpCodes() throws {
+    @Test func testParseOpCodes() throws {
         let parser = Chip8OperationParser();
         
-        XCTAssertEqual(ClearScreen(), parser.decode(0x00E0) as? ClearScreen)
+        #expect(ClearScreen() == parser.decode(0x00E0) as? ClearScreen)
         
-        XCTAssertNotEqual(ClearScreen(), parser.decode(0x00E1) as? ClearScreen)
-        XCTAssertEqual(Unknown(operationCode: 0x00E1), parser.decode(0x00E1) as? Unknown) // 0x00E1 is not a valid op code -> unknown
+        #expect(ClearScreen() != parser.decode(0x00E1) as? ClearScreen)
+        #expect(Unknown(operationCode: 0x00E1) == parser.decode(0x00E1) as? Unknown) // 0x00E1 is not a valid op code -> unknown
         
-        XCTAssertEqual(JumpToAddress(address: 0x222), parser.decode(0x1222) as? JumpToAddress)
-        XCTAssertEqual(JumpToAddressPlusV0(address: 0x222), parser.decode(0xB222) as? JumpToAddressPlusV0)
+        #expect(JumpToAddress(address: 0x222) == parser.decode(0x1222) as? JumpToAddress)
+        #expect(JumpToAddressPlusV0(address: 0x222) == parser.decode(0xB222) as? JumpToAddressPlusV0)
         
-        XCTAssertEqual(ConditionalSkipRegisterValue(registerIndex: 5, value: 0x22, isEqual: true), parser.decode(0x3522) as? ConditionalSkipRegisterValue)
+        #expect(ConditionalSkipRegisterValue(registerIndex: 5, value: 0x22, isEqual: true) == parser.decode(0x3522) as? ConditionalSkipRegisterValue)
         
-        XCTAssertEqual(RegistersOperation(registerXIndex: 1, registerYIndex: 0, operation: .subtractSecondFromFirst), parser.decode(0x8105) as? RegistersOperation)
-        XCTAssertEqual(RegistersOperation(registerXIndex: 1, registerYIndex: 0xA, operation: .subtractFirstFromSecond), parser.decode(0x81A7) as? RegistersOperation)
+        #expect(RegistersOperation(registerXIndex: 1, registerYIndex: 0, operation: .subtractSecondFromFirst) == parser.decode(0x8105) as? RegistersOperation)
+        #expect(RegistersOperation(registerXIndex: 1, registerYIndex: 0xA, operation: .subtractFirstFromSecond) == parser.decode(0x81A7) as? RegistersOperation)
         
-        XCTAssertEqual(RegistersOperation(registerXIndex: 1, registerYIndex: 9, operation: .shiftRight), parser.decode(0x8196) as? RegistersOperation)
-        XCTAssertNotEqual(RegistersOperation(registerXIndex: 1, registerYIndex: 9, operation: .shiftLeft), parser.decode(0x8196) as? RegistersOperation)
+        #expect(RegistersOperation(registerXIndex: 1, registerYIndex: 9, operation: .shiftRight) == parser.decode(0x8196) as? RegistersOperation)
+        #expect(RegistersOperation(registerXIndex: 1, registerYIndex: 9, operation: .shiftLeft) != parser.decode(0x8196) as? RegistersOperation)
         
-        XCTAssertEqual(DrawSprite(height: 8, registerXIndex: 3, registerYIndex: 1), parser.decode(0xD318) as? DrawSprite)
-        XCTAssertEqual(DrawSprite(height: 0xF, registerXIndex: 0xF, registerYIndex: 0xF), parser.decode(0xDFFF) as? DrawSprite)
+        #expect(DrawSprite(height: 8, registerXIndex: 3, registerYIndex: 1) == parser.decode(0xD318) as? DrawSprite)
+        #expect(DrawSprite(height: 0xF, registerXIndex: 0xF, registerYIndex: 0xF) == parser.decode(0xDFFF) as? DrawSprite)
     }
     
     /// Will test decoding machine opcodes and encoding back.
-    func testDecodeEncode() {
+    @Test func testDecodeEncode() {
         let testCases: [(UShort, any Chip8OperationCommand)] = [
             // Test cases for all operations
             (0x00E0, ClearScreen()),
@@ -63,8 +63,8 @@ final class Chip8OperationParserTests: XCTestCase {
             let parser = Chip8OperationParser()
             
             let expectedOperationCode = parser.encode(expectedOperation)
-            XCTAssertEqual(expectedOperationCode, opCode,
-                           "Expected operation code \(expectedOperation) did not match the original machine code \(opCode).")
+            #expect(expectedOperationCode == opCode,
+                    "Expected operation code \(expectedOperation) did not match the original machine code \(opCode).")
             
             let decodedOperation = parser.decode(opCode)
 
@@ -73,7 +73,7 @@ final class Chip8OperationParserTests: XCTestCase {
         
 
             // Ensure the re-encoded machine code matches the original machine code
-            XCTAssertEqual(reEncodedMachineCode, opCode,
+            #expect(reEncodedMachineCode == opCode,
                            "Re-encoded machine code did not match the original machine code for operation \(expectedOperation).")
         }
     }

--- a/Tests/Chip8iEmulationCoreTests/Chip8SystemTests.swift
+++ b/Tests/Chip8iEmulationCoreTests/Chip8SystemTests.swift
@@ -1,16 +1,8 @@
-import XCTest
+import Testing
 @testable import Chip8iEmulationCore
 
-final class Chip8SystemTests: XCTestCase {
-    func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
-
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
-    }
-    
-    func testLoadFontAndChip8ProgramRomIntoSystemRam() throws {
+struct Chip8SystemTests {
+    @Test func testLoadFontAndChip8ProgramRomIntoSystemRam() async throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
         // Any test you write for XCTest can be annotated as throws and async.
@@ -18,134 +10,149 @@ final class Chip8SystemTests: XCTestCase {
         // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
         let system = Chip8System()
         
-        system.loadFont()
-        XCTAssertEqual(Chip8SystemState.DefaultFontSet[0], system.state.randomAccessMemory[system.state.fontStartingLocation.toInt]) // first byte of font
-        XCTAssertEqual(Chip8SystemState.DefaultFontSet[0x4F], system.state.randomAccessMemory[system.state.fontStartingLocation.toInt + Int(0x4F)]) // last (80th) byte of font at index 0x4F (79)
+        var ram = await system.exportState().randomAccessMemory
+        let fontStartLocation = await system.exportState().fontStartingLocation.toInt
+        
+        await system.loadFont()
+        ram = await system.exportState().randomAccessMemory
+        #expect(Chip8SystemState.DefaultFontSet[0] == ram[fontStartLocation]) // first byte of font
+        #expect(Chip8SystemState.DefaultFontSet[0x4F] == ram[fontStartLocation + Int(0x4F)]) // last (80th) byte of font at index 0x4F (79)
         
         let programROM: [UByte] = [0x00, 0x01]
-        system.loadProgram(programROM)
-        XCTAssertEqual(4096, system.state.randomAccessMemory.count)
-        XCTAssertEqual(programROM[0], system.state.randomAccessMemory[0x200])
-        XCTAssertEqual(programROM[1], system.state.randomAccessMemory[0x201])
+        await system.loadProgram(programROM)
+        ram = await system.exportState().randomAccessMemory
+        #expect(4096 == ram.count)
+        #expect(programROM[0] == ram[0x200])
+        #expect(programROM[1] == ram[0x201])
     }
     
-    func testExecuteOperationAndPcChange() throws {
+    @Test func testExecuteOperationAndPcChange() async throws {
         let parser = Chip8OperationParser();
         let system = Chip8System()
         let programROM: [UByte] = [0x00, 0xE0]
-        system.loadProgram(programROM)
+        await system.loadProgram(programROM)
         
-        XCTAssertEqual(0x200, system.state.pc)
-        var opCodeToBeExecuted = try system.fetchOperationCode(memoryLocation: system.state.pc)
-        XCTAssertEqual(UShort(0x00E0), opCodeToBeExecuted) // Chip8 uses big endian
+        var pc = (await system.exportState()).pc
+        #expect(0x200 == pc)
+        var opCodeToBeExecuted = try await system.fetchOperationCode(memoryLocation: pc)
+        #expect(UShort(0x00E0) == opCodeToBeExecuted) // Chip8 uses big endian
         
         // Execute the operation
-        try system.executeOperation(operation: parser.decode(opCodeToBeExecuted))
+        try await system.executeOperation(operation: parser.decode(opCodeToBeExecuted))
         
         // PC should change
-        XCTAssertEqual(0x202, system.state.pc)
-        opCodeToBeExecuted = try system.fetchOperationCode(memoryLocation: system.state.pc)
-        XCTAssertEqual(UShort(0x0), opCodeToBeExecuted)
+        pc = (await system.exportState()).pc
+        #expect(0x202 == pc)
+        opCodeToBeExecuted = try await system.fetchOperationCode(memoryLocation: pc)
+        #expect(UShort(0x0) == opCodeToBeExecuted)
     }
     
-    func testDrawOperationAndCollision() throws {
+    @Test func testDrawOperationAndCollision() async throws {
         let system = Chip8System()
-        system.loadFont()
+        await system.loadFont()
         
         // Set value 2 into V0, other registers are set to zero
-        try system.executeOperation(operation: SetValueToRegister(registerIndex: 0, value: 2))
+        try await system.executeOperation(operation: SetValueToRegister(registerIndex: 0, value: 2))
         
         // Set address of font character at the index 2 into I. In default font this is the digit 2 character itself.
-        try system.executeOperation(operation: SetFontCharacterAddressToIndexRegister(registerIndex: 0))
+        try await system.executeOperation(operation: SetFontCharacterAddressToIndexRegister(registerIndex: 0))
         
         
         // Draw the digit 2 character at the location x=0, y=0 (registers 3 and 4 have initial zero value inside them)
-        try system.executeOperation(operation: DrawSprite(height: 0x5, registerXIndex: 3, registerYIndex: 4))
-        //print(EmulationConsoleLogger.getStringOutput(system.state.Output, width: 64, height: 32))
+        try await system.executeOperation(operation: DrawSprite(height: 0x5, registerXIndex: 3, registerYIndex: 4))
+        //print(EmulationConsoleLogger.getStringOutput((await system.exportState()).Output, width: 64, height: 32))
         
         // Cut out selected screen area x0y0 x8y5
-        var selectedArea = system.state.output.getSelectedArea(locationX: 0, locationY: 0, selectedWidth: 8, selectedHeight: 5, totalWidth: 64, totalHeight: 32)
+        var selectedArea = (await system.exportState()).output.getSelectedArea(locationX: 0, locationY: 0, selectedWidth: 8, selectedHeight: 5, totalWidth: 64, totalHeight: 32)
         // [Bool] pixels -> [Byte] sprite data where 1 byte is 1 row
         var selectedAreaData = selectedArea?.toRowsBytes(totalWidth: 8, totalHeight: 5)
         
         // digit 2 font character byte representation
-        let fontCharacterStartingAddress: Int = system.state.fontStartingLocation.toInt + 2 * 5
-        let fontCharacterData = Array(system.state.randomAccessMemory[fontCharacterStartingAddress..<fontCharacterStartingAddress+5])
-        
-        XCTAssertEqual(fontCharacterData, selectedAreaData) // Font character is drawn on the screen
-        XCTAssertEqual(0, system.state.registers[0xF]) // No collision
+        let fontCharacterStartingAddress: Int = (await system.exportState()).fontStartingLocation.toInt + 2 * 5
+        let fontCharacterData = Array((await system.exportState()).randomAccessMemory[fontCharacterStartingAddress..<fontCharacterStartingAddress+5])
+        var registers = (await system.exportState()).registers
+        #expect(fontCharacterData == selectedAreaData) // Font character is drawn on the screen
+        #expect(0 == registers[0xF]) // No collision
         
         // Test collision
         // Draw the digit 2 on the same place as before -> Collision
-        try system.executeOperation(operation: DrawSprite(height: 0x5, registerXIndex: 3, registerYIndex: 4))
+        try await system.executeOperation(operation: DrawSprite(height: 0x5, registerXIndex: 3, registerYIndex: 4))
         
-        selectedArea = system.state.output.getSelectedArea(locationX: 0, locationY: 0, selectedWidth: 8, selectedHeight: 5, totalWidth: 64, totalHeight: 32)
+        selectedArea = (await system.exportState()).output.getSelectedArea(locationX: 0, locationY: 0, selectedWidth: 8, selectedHeight: 5, totalWidth: 64, totalHeight: 32)
         selectedAreaData = selectedArea?.toRowsBytes(totalWidth: 8, totalHeight: 5)
-        XCTAssertNotEqual(fontCharacterData, selectedAreaData) // Font character is not on the screen anymore
-        XCTAssertEqual([0, 0, 0, 0, 0], selectedAreaData) // That area is now empty/erased cause of collision
-        XCTAssertEqual(1, system.state.registers[0xF]) // Collision was registered
+        registers = (await system.exportState()).registers
+        #expect(fontCharacterData != selectedAreaData) // Font character is not on the screen anymore
+        #expect([0, 0, 0, 0, 0] == selectedAreaData) // That area is now empty/erased cause of collision
+        #expect(1 == registers[0xF]) // Collision was registered
     }
     
-    func testLoadAndExportState() throws {
+    @Test func testLoadAndExportState() async throws {
         let parser = Chip8OperationParser();
         let system = Chip8System()
         
         let programROM: [UByte] = [0x00, 0xE0]
-        system.loadProgram(programROM)
+        await system.loadProgram(programROM)
         
-        let initialSavedState = system.state
+        let initialSavedState = (await system.exportState())
         
-        XCTAssertEqual(0x200, system.state.pc)
-        var opCodeToBeExecuted = try system.fetchOperationCode(memoryLocation: system.state.pc)
-        XCTAssertEqual(UShort(0x00E0), opCodeToBeExecuted) // Chip8 uses big endian
+        var pc = await system.exportState().pc
+        #expect(0x200 == pc)
+        var opCodeToBeExecuted = try await system.fetchOperationCode(memoryLocation: pc)
+        #expect(UShort(0x00E0) == opCodeToBeExecuted) // Chip8 uses big endian
         
         // Execute the operation
-        try system.executeOperation(operation: parser.decode(opCodeToBeExecuted))
-        
+        try await system.executeOperation(operation: parser.decode(opCodeToBeExecuted))
+        pc = await system.exportState().pc
         // PC of system should change
-        XCTAssertEqual(0x202, system.state.pc)
-        opCodeToBeExecuted = try system.fetchOperationCode(memoryLocation: system.state.pc)
-        XCTAssertEqual(UShort(0x0), opCodeToBeExecuted)
+        #expect(0x202 == pc)
+        opCodeToBeExecuted = try await system.fetchOperationCode(memoryLocation: pc)
+        #expect(UShort(0x0) == opCodeToBeExecuted)
         
-        XCTAssertEqual(0x200, initialSavedState.pc) // Exported initial state was not changed
+        #expect(0x200 == initialSavedState.pc) // Exported initial state was not changed
         
-        system.loadState(initialSavedState)
-        XCTAssertEqual(0x200, system.state.pc)
-        opCodeToBeExecuted = try system.fetchOperationCode(memoryLocation: system.state.pc)
-        XCTAssertEqual(UShort(0x00E0), opCodeToBeExecuted) // Initial state successfully loaded back
+        await system.loadState(initialSavedState)
+        pc = await system.exportState().pc
+        #expect(0x200 == pc)
+        opCodeToBeExecuted = try await system.fetchOperationCode(memoryLocation: pc)
+        #expect(UShort(0x00E0) == opCodeToBeExecuted) // Initial state successfully loaded back
     }
     
-    func testKeys() {
+    @Test func testKeys() async {
         let system = Chip8System()
         let key1: UByte = 0x1
-        let key1Index = key1.toInt // Chip8 key 0x1 is saved at the index 1 in the system.state.InputKeys. Same for the rest of the 16 keys. 0x0 at index 0 and 0xF at index 15
-        
-        XCTAssertEqual(false, system.state.inputKeys[key1.toInt]) // All keys initially released (not pressed)
+        let key1Index = key1.toInt // Chip8 key 0x1 is saved at the index 1 in the (await system.exportState()).InputKeys. Same for the rest of the 16 keys. 0x0 at index 0 and 0xF at index 15
+        var inputKeys = await system.exportState().inputKeys
+        #expect(false == inputKeys[key1.toInt]) // All keys initially released (not pressed)
         
         // Press down one key
-        system.keyDown(key: key1)
-        XCTAssertEqual(true, system.state.inputKeys[key1Index])
+        await system.keyDown(key: key1)
+        inputKeys = await system.exportState().inputKeys
+        #expect(true == inputKeys[key1Index])
         
         // Release the key
-        system.keyUp(key: key1)
-        XCTAssertEqual(false, system.state.inputKeys[key1Index]) // Key should be released now
+        await system.keyUp(key: key1)
+        inputKeys = await system.exportState().inputKeys
+        #expect(false == inputKeys[key1Index]) // Key should be released now
         
         let keyF: UByte = 0xF
         let keyFIndex = keyF.toInt
         
         // Multiple keys can be pressed down at the same time
-        system.keyDown(key: key1)
-        system.keyDown(key: keyF)
-        XCTAssertEqual(true, system.state.inputKeys[key1Index])
-        XCTAssertEqual(true, system.state.inputKeys[keyFIndex])
+        await system.keyDown(key: key1)
+        await system.keyDown(key: keyF)
+        inputKeys = await system.exportState().inputKeys
+        #expect(true == inputKeys[key1Index])
+        #expect(true == inputKeys[keyFIndex])
         
-        system.keyUp(key: key1)
-        system.keyUp(key: keyF)
-        XCTAssertEqual(false, system.state.inputKeys[key1Index])
-        XCTAssertEqual(false, system.state.inputKeys[keyFIndex])
+        await system.keyUp(key: key1)
+        await system.keyUp(key: keyF)
+        inputKeys = await system.exportState().inputKeys
+        
+        #expect(false == inputKeys[key1Index])
+        #expect(false == inputKeys[keyFIndex])
     }
 
-    func testPerformanceExample() throws {
+    @Test func testPerformanceExample() throws {
         // TODO: Implement
         // This is an example of a performance test case.
 //        measure {


### PR DESCRIPTION
- Swift 6 set as minimal version
- New concurrency actors and checks added 
- Moved from XCTest to Testing library